### PR TITLE
LunaSysMgr.service: Make sure we start only after configurator

### DIFF
--- a/LunaSysMgr.service
+++ b/LunaSysMgr.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Luna System Manager
-After=LunaSysService.service nyx.target
+After=LunaSysService.service nyx.target configurator.service
 Requires=LunaSysService.service
 BindsTo=nyx.target
 


### PR DESCRIPTION
As per https://github.com/openwebos/luna-sysmgr/blob/1393f0af5dd8d9f0e9cc79627f4acb226f8c8d45/LunaSysMgr.upstart#L2 configurator needs to finish first. This should sort stuff like:
Sep 20 05:40:54 qemux86 mojodb-luna[554]: [] [pmlog] DB8 MOJ_SERVICE_WARNING {"sender":"com.palm.systemmanager","method":"del","payload":{"query":{"from":"com.palm.securitypolicy:1","where":[{"op":"=","prop":"isTemp","val":true}]}},"error":"kind not registered: 'com.palm.securitypolicy:1'","reqErr":-3970}

Signed-off-by: Herman van Hazendonk github.com@herrie.org
